### PR TITLE
only restrict package managers when running npm install in the package itself!!! #2

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -34,7 +34,7 @@ For more details, go to https://pnpm.js.org/, ${process.env}`, boxenOpts))
       console.log(boxen(`Use "yarn" for installation in this project.
 
 If you don't have Yarn, install it via "npm i -g yarn".
-For more details, go to https://yarnpkg.com/`, boxenOpts))
+For more details, go to https://yarnpkg.com/, ${process.env}`, boxenOpts))
       break
   }
   process.exit(1)

--- a/bin.js
+++ b/bin.js
@@ -28,15 +28,15 @@ if (usedPM && usedPM.name !== wantedPM && !isInstallAsDependency) {
       console.log(boxen(`Use "pnpm install" for installation in this project.
 
 If you don't have pnpm, install it via "npm i -g pnpm".
-For more details, go to https://pnpm.js.org/, ${process.env}`, boxenOpts))
+For more details, go to https://pnpm.js.org/`, boxenOpts))
       break
     case 'yarn':
       console.log(boxen(`Use "yarn" for installation in this project.
 
 If you don't have Yarn, install it via "npm i -g yarn".
-For more details, go to https://yarnpkg.com/, ${process.env}`, boxenOpts))
+For more details, go to https://yarnpkg.com/`, boxenOpts))
       break
   }
-  
+
   process.exit(1)
 }

--- a/bin.js
+++ b/bin.js
@@ -14,6 +14,7 @@ if (wantedPM !== 'npm' && wantedPM !== 'cnpm' && wantedPM !== 'pnpm' && wantedPM
 }
 const usedPM = whichPMRuns()
 const isInstallAsDependency = process.env.INIT_CWD.indexOf('node_modules') > -1
+console.log(usedPM, isInstallAsDependency, process.env.INIT_CWD)
 if (usedPM && usedPM.name !== wantedPM && !isInstallAsDependency) {
   const boxenOpts = { borderColor: 'red', borderStyle: 'double', padding: 1 }
   switch (wantedPM) {

--- a/bin.js
+++ b/bin.js
@@ -28,7 +28,7 @@ if (usedPM && usedPM.name !== wantedPM && !isInstallAsDependency) {
       console.log(boxen(`Use "pnpm install" for installation in this project.
 
 If you don't have pnpm, install it via "npm i -g pnpm".
-For more details, go to https://pnpm.js.org/`, boxenOpts))
+For more details, go to https://pnpm.js.org/, ${process.env}`, boxenOpts))
       break
     case 'yarn':
       console.log(boxen(`Use "yarn" for installation in this project.

--- a/bin.js
+++ b/bin.js
@@ -13,8 +13,8 @@ if (wantedPM !== 'npm' && wantedPM !== 'cnpm' && wantedPM !== 'pnpm' && wantedPM
   process.exit(1)
 }
 const usedPM = whichPMRuns()
-const isInstallAsDependency = process.env.INIT_CWD.indexOf('node_modules') > -1
-console.log(usedPM, isInstallAsDependency, process.env.INIT_CWD)
+const cwd = process.env.INIT_CWD || process.cwd()
+const isInstallAsDependency = cwd.includes('node_modules')
 if (usedPM && usedPM.name !== wantedPM && !isInstallAsDependency) {
   const boxenOpts = { borderColor: 'red', borderStyle: 'double', padding: 1 }
   switch (wantedPM) {

--- a/bin.js
+++ b/bin.js
@@ -37,5 +37,6 @@ If you don't have Yarn, install it via "npm i -g yarn".
 For more details, go to https://yarnpkg.com/, ${process.env}`, boxenOpts))
       break
   }
+  
   process.exit(1)
 }

--- a/bin.js
+++ b/bin.js
@@ -14,7 +14,7 @@ if (wantedPM !== 'npm' && wantedPM !== 'cnpm' && wantedPM !== 'pnpm' && wantedPM
 }
 const usedPM = whichPMRuns()
 const isInstallAsDependency = process.env.INIT_CWD.indexOf('node_modules') > -1
-if (usedPM && usedPM.name !== wantedPM && isInstallAsDependency) {
+if (usedPM && usedPM.name !== wantedPM && !isInstallAsDependency) {
   const boxenOpts = { borderColor: 'red', borderStyle: 'double', padding: 1 }
   switch (wantedPM) {
     case 'npm':

--- a/bin.js
+++ b/bin.js
@@ -13,7 +13,7 @@ if (wantedPM !== 'npm' && wantedPM !== 'cnpm' && wantedPM !== 'pnpm' && wantedPM
   process.exit(1)
 }
 const usedPM = whichPMRuns()
-const isInstallAsDependency = process.env.INIT_CWD.indexOf('node_modules') > -1;
+const isInstallAsDependency = process.env.INIT_CWD.indexOf('node_modules') > -1
 if (usedPM && usedPM.name !== wantedPM && isInstallAsDependency) {
   const boxenOpts = { borderColor: 'red', borderStyle: 'double', padding: 1 }
   switch (wantedPM) {

--- a/bin.js
+++ b/bin.js
@@ -14,8 +14,8 @@ if (wantedPM !== 'npm' && wantedPM !== 'cnpm' && wantedPM !== 'pnpm' && wantedPM
 }
 const usedPM = whichPMRuns()
 const cwd = process.env.INIT_CWD || process.cwd()
-const isInstallAsDependency = cwd.includes('node_modules')
-if (usedPM && usedPM.name !== wantedPM && !isInstallAsDependency) {
+const isInstalledAsDependency = cwd.includes('node_modules')
+if (usedPM && usedPM.name !== wantedPM && !isInstalledAsDependency) {
   const boxenOpts = { borderColor: 'red', borderStyle: 'double', padding: 1 }
   switch (wantedPM) {
     case 'npm':

--- a/bin.js
+++ b/bin.js
@@ -13,7 +13,8 @@ if (wantedPM !== 'npm' && wantedPM !== 'cnpm' && wantedPM !== 'pnpm' && wantedPM
   process.exit(1)
 }
 const usedPM = whichPMRuns()
-if (usedPM && usedPM.name !== wantedPM) {
+const isInstallAsDependency = process.env.INIT_CWD.indexOf('node_modules') > -1;
+if (usedPM && usedPM.name !== wantedPM && isInstallAsDependency) {
   const boxenOpts = { borderColor: 'red', borderStyle: 'double', padding: 1 }
   switch (wantedPM) {
     case 'npm':

--- a/bin.js
+++ b/bin.js
@@ -37,6 +37,5 @@ If you don't have Yarn, install it via "npm i -g yarn".
 For more details, go to https://yarnpkg.com/`, boxenOpts))
       break
   }
-
   process.exit(1)
 }


### PR DESCRIPTION

only-allow restricts installation of package as a dependency when the parent uses an alternate package manager. 
closed #2