### PR TITLE
fix: abort PM enforcement if the script runs in a dependency

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -14,7 +14,7 @@ if (wantedPM !== 'npm' && wantedPM !== 'cnpm' && wantedPM !== 'pnpm' && wantedPM
 }
 const usedPM = whichPMRuns()
 const cwd = process.env.INIT_CWD || process.cwd()
-const isInstalledAsDependency = cwd.includes('node_modules')
+const isInstalledAsDependency = cwd.includes('node_modules') || cwd.includes('_cacache')
 if (usedPM && usedPM.name !== wantedPM && !isInstalledAsDependency) {
   const boxenOpts = { borderColor: 'red', borderStyle: 'double', padding: 1 }
   switch (wantedPM) {


### PR DESCRIPTION
The reason why is that NPM runs the preinstall script from the cache instead of from node_modules.

One way to detect that is by testing the presence of the `_cacache` which is the folder NPM uses for its cache.

Closes #13 

