### PR TITLE
Remove wrong trailing quotes from bun message

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -49,7 +49,7 @@ For more details, go to https://yarnpkg.com/`))
     case 'bun':
       console.log(box(`Use "bun install" for installation in this project.
 
-If you don't have Bun, go to https://bun.sh/docs/installation and find installation method that suits your environment".`))
+If you don't have Bun, go to https://bun.sh/docs/installation and find installation method that suits your environment.`))
       break
   }
   process.exit(1)


### PR DESCRIPTION
There was a trailing quote at the end of the message:
```

╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗
║                                                                                                                              ║
║   Use "bun install" for installation in this project.                                                                        ║
║                                                                                                                              ║
║   If you don't have Bun, go to https://bun.sh/docs/installation and find installation method that suits your environment".   ║
║                                                                                                                              ║
╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝

```

i found it a bit confusing so i removed it